### PR TITLE
Use bundled zlib on macOS

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -1,5 +1,5 @@
 declare_args() {
-  if (target_os != "win" && rebase_path(".", "//") != ".") {
+  if (target_os == "linux" && rebase_path(".", "//") != ".") {
     zlib = "system"
   } else {
     zlib = "bundled"
@@ -9,9 +9,7 @@ assert(zlib == "system" || zlib == "bundled")
 
 if (zlib == "bundled") {
   config("zlib_private") {
-    defines = [
-      "HAVE_STDARG_H=1",
-    ]
+    defines = [ "HAVE_STDARG_H=1" ]
     if (current_toolchain != "//build/lib/win:msvc") {
       cflags = [
         "-Wall",


### PR DESCRIPTION
It’s not possible to build libpng for old macOS on new macOS when using bundled zlib, because the latest SDKs state that they have zlib 1.2.11, and libpng will incorrectly try to use features from that version.